### PR TITLE
Update repos in meta-netkans

### DIFF
--- a/CKAN/CryoTanks-Core.netkan
+++ b/CKAN/CryoTanks-Core.netkan
@@ -3,12 +3,12 @@
     "identifier":   "CryoTanks-Core",
     "abstract":     "This is the CryoTanks plugin stand-alone, for adding functionality to other mods. It contains no parts and does nothing by itself.",
     "name":         "Cryo Tanks Core",
-    "$kref":        "#/ckan/github/ChrisAdderley/CryoTanks",
+    "$kref":        "#/ckan/github/post-kerbin-mining-corporation/CryoTanks",
     "$vref":        "#/ckan/ksp-avc/CryoTanks.version",
     "license":      "MIT",
     "resources": {
-      "homepage": "https://github.com/ChrisAdderley/CryoTanks/wiki",
-      "repository": "https://github.com/ChrisAdderley/CryoTanks"
+      "homepage": "https://github.com/post-kerbin-mining-corporation/CryoTanks/wiki",
+      "repository": "https://github.com/post-kerbin-mining-corporation/CryoTanks"
     },
     "supports": [
         { "name": "CryoTanks" }

--- a/CKAN/CryoTanks.netkan
+++ b/CKAN/CryoTanks.netkan
@@ -3,12 +3,12 @@
     "identifier":   "CryoTanks",
     "abstract":     "A set of fuel tanks for containing Liquid Hydrogen. Also adds Liquid Hydrogen storage to most stock tanks",
     "name":         "Cryo Tanks",
-    "$kref":        "#/ckan/github/ChrisAdderley/CryoTanks",
+    "$kref":        "#/ckan/github/post-kerbin-mining-corporation/CryoTanks",
     "$vref":        "#/ckan/ksp-avc/CryoTanks.version",
     "license":      "restricted",
     "resources": {
-      "homepage": "https://github.com/ChrisAdderley/CryoTanks/wiki",
-      "repository": "https://github.com/ChrisAdderley/CryoTanks"
+      "homepage": "https://github.com/post-kerbin-mining-corporation/CryoTanks/wiki",
+      "repository": "https://github.com/post-kerbin-mining-corporation/CryoTanks"
     },
     "depends": [
         { "name": "CryoTanks-Core"   },


### PR DESCRIPTION
GitHub likes to throw bogus API rate limiting errors when the CKAN bot crawls mods after their repositories change.
Now these are updated from ChrisAdderley to post-kerbin-mining-corporation.

Previously updated the link to the meta-netkans in KSP-CKAN/NetKAN#8264.

Tagging @ChrisAdderley because GitHub is shy about sending notifications for pull requests.