### PR TITLE
ProceduralParts consistent to stock tanks in mass and methane support.

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
@@ -116,3 +116,27 @@
 		}
 	}
 }
+
+// Rename HydroOxi back after SMURFF runs
+@PART[proceduralTankLiquid]:NEEDS[SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:AFTER[zzz_SMURFF]
+{
+	@MODULE[TankContentSwitcher]
+	{
+		@TANK_TYPE_OPTION[HydroOxi]
+		{
+			@name = LqdHydrogen+Oxidizer
+		}
+	}
+}
+
+// Rename HydroOxi back in case SMURFF was not installed
+@PART[proceduralTankLiquid]:NEEDS[!SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
+{
+	@MODULE[TankContentSwitcher]
+	{
+		@TANK_TYPE_OPTION[HydroOxi]
+		{
+			@name = LqdHydrogen+Oxidizer
+		}
+	}
+}

--- a/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
@@ -1,5 +1,5 @@
 // Procedural Fuel Tanks Patch
-// Most recent author: madman2003
+// Most recent author: Ve
 
 @PART[procedural*Liquid]:NEEDS[ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
 {
@@ -8,51 +8,44 @@
 		TANK_TYPE_OPTION
 		{
 			name = LqdHydrogen
-			dryDensity = 0.01417 // kg of tank mass per liter (1 unit) of LqdHydrogen, 20% of wet-mass
-			costMultiplier = 0.035
-			// Based on observation that LH2 is 1/20 the cost of LF
+			dryDensity = 0.0187
+			costMultiplier = 1.61
 			RESOURCE
 			{
 				name = LqdHydrogen
-				// How many units (1 liter) of LqdHydrogen fit into 1 metric tonne of tank
-				// 0.01417 kg tank per liter LqdHydrogen
-				// 70.5716 liter per kg tank
-				// 70571.6 liter per metric tonne of tank
-				unitsPerT = 70571.6
+				unitsPerKL = 1303.79733
 			}
 		}
 		TANK_TYPE_OPTION
 		{
 			name = LqdHydrogen+Oxidizer
-			// 12.5% of wet-mass of Oxidizer is dry-mass, so 87,5% is fuel
-			// 20% of wet-mass of LqdHydrogen is dry-mass, so 80% is fuel
-			// every 16 units of fuel, 15 (*1 Liter) is LqdHydrogen and 1 (*5 Liters) is Oxidizer
-			// so for every 4 liters, 3 liter will be LqdHydrogen and 1 liters will be Oxidizer
-			// 15 liters (15 units) of LqdHyrodogen has a mass of 15*0.00007 = 0.00105 metric tonnes
-			// 5 liters (1 unit) of Oxidizer has a mass of 1*0.005 = 0.005 metric tonnes
-			// 15 liters (15 units) of LqdHydrogen tank has a mass of (12.5%/87,5%) * 0.00105 = 0.00015 metric tonnes
-			// 5 liters (1 unit) of Oxidizer tank has a mass of (20%/80%) * 0.005 = 0.0014 metric tonnes
-			// the average liter of dry-mass of tank has a dry density of (0.00015 + 0.0014)/20 = 0.0000775 metric tonnes
-			dryDensity = 0.0775 // in kg/L, not the more "KSP community resource pack typical" metric tonnes/L or 1000 kg/L
-			costMultiplier = 0.785
-			// Based on observation that LH2 is 1/20 the cost of LF and adding the cost mult for oxidizer only
-
-			// How many units of Oxidizer and LqdHydrogen fit into 1 metric tonne of tank
-			// Every 16 units, 1 unit will be Oxidizer and 15 units will be LqdHydrogen
-			// 1 unit (5 L) Oxidizer-tank is 0.0014 metric tonnes
-			// 15 units (15 L) LqdHydrogen-tank is 0.00015 metric tonnes
-			// The sum of that is 0.00155 metric tonnes, so:
-			// 645.2 units of Oxidizer per metric tonne of tank
-			// 9677.4 units of LqdHydrogen per metric tonne of tank
+			dryDensity = 0.0487
+			costMultiplier = 1.35
 			RESOURCE
 			{
 				name = LqdHydrogen
-				unitsPerT = 9677.4
+				unitsPerKL = 868.32902
 			}
 			RESOURCE
 			{
 				name = Oxidizer
-				unitsPerT = 645.2
+				unitsPerKL = 57.8886
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = MethaOxi
+			dryDensity = 0.0909
+			costMultiplier = 1.3
+			RESOURCE
+			{
+				name = LqdMethane
+				unitsPerKL = 325.94933
+			}
+			RESOURCE
+			{
+				name = Oxidizer
+				unitsPerKL = 108.64977
 			}
 		}
 	}
@@ -69,7 +62,7 @@
 			BoiloffRate = 0.05
 			CoolingCost = 0.05
 		}
-    BOILOFFCONFIG
+		BOILOFFCONFIG
 		{
 			FuelName = LqdMethane
 			// in % per hr

--- a/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
@@ -13,12 +13,13 @@
 			RESOURCE
 			{
 				name = LqdHydrogen
-				unitsPerKL = 1303.79733
+				// 1303.79733/0.0187
+				unitsPerT = 69721.78235
 			}
 		}
 		TANK_TYPE_OPTION
 		{
-			name = LqdHydrogen+Oxidizer
+			name = HydroOxi
 			dryDensity = 0.0487
 			costMultiplier = 1.35
 			RESOURCE
@@ -68,6 +69,50 @@
 			// in % per hr
 			BoiloffRate = 0.005
 			CoolingCost = 0.02
+		}
+	}
+}
+
+@PART[proceduralTankLiquid]:NEEDS[SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
+{
+	@MODULE[TankContentSwitcher]
+	{
+		// This runs before SMURFF.
+		// Hydrogen is already patched well by SMURFF
+		@TANK_TYPE_OPTION[HydroOxi]
+		{
+			// 1/unitsPerT
+			lh2mass = 0.00001417
+			@lh2mass *= #$RESOURCE[LqdHydrogen]/unitsPerKL$
+			@lh2mass /= #$@SMURFFCONFIG/lh2zbofactor$
+
+			oxmass = 0.000625
+			@oxmass *= #$RESOURCE[Oxidizer]/unitsPerKL$
+			@oxmass /= #$@SMURFFCONFIG/lfofactor$
+
+			@dryDensity = #$lh2mass$
+			@dryDensity += #$oxmass$
+
+			-lh2mass = delete
+			-oxmass = delete
+		}
+		@TANK_TYPE_OPTION[MethaOxi]
+		{
+			// (B9_TANK_TYPE[LM]/tankMass)
+			lh2mass = 0.000070935
+			@lh2mass *= #$RESOURCE[LqdMethane]/unitsPerKL$
+			@lh2mass /= #$@SMURFFCONFIG/lfofactor$
+
+			oxmass = 0.000625
+			@oxmass *= #$RESOURCE[Oxidizer]/unitsPerKL$
+			//TODO: maybe a factor in between LFO and LH2 should be used, isnt this too good?
+			@oxmass /= #$@SMURFFCONFIG/lfofactor$
+
+			@dryDensity = #$lh2mass$
+			@dryDensity += #$oxmass$
+
+			-lh2mass = delete
+			-oxmass = delete
 		}
 	}
 }


### PR DESCRIPTION
The LFO is left untouched, but appears to be consistent to stock tanks. MethaOxi was added. MethaOxi and HydroOxi were made consistent with the insulated cryo tanks in both dry mass and cost.