### PR TITLE
Updates for Procedural Fuel Tanks and Procedural Wings

### DIFF
--- a/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
@@ -17,7 +17,7 @@ CT_PROCEDURAL_TAX
 
 !CT_PROCEDURAL_TAX:LAST[CryoTanks] {}
 
-@PART[procedural*Liquid]:NEEDS[ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
+@PART[procedural*Liquid]:NEEDS[CryoTanks&ProceduralParts&!RealFuels&!ModularFuelTanks]
 {
 	@MODULE[TankContentSwitcher]
 	{

--- a/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralFuelTanks.cfg
@@ -1,56 +1,154 @@
 // Procedural Fuel Tanks Patch
-// Most recent author: Ve
+// Most recent author: Scialytic
+
+// ProceduralParts seems to recommend using unitsPerT rather than unitsPerKL.
+// ref: https://github.com/KSP-RO/ProceduralParts/wiki/Calculation-of-tank-config-parameters
+// Their rationale about mass ratios being more important than drag seems solid, so I'll stick with unitsPerT.
+
+// Reminder: Avoid using dryDensity to derive other values.  It's not consistent even between stock parts.
+
+// The costMultiplier values inside the TANK_TYPE_OPTIONs below are set to roughly match the cost of equivalent stock/cryo tanks.
+// This way it's easy to scale them all up as judged appropriate using priceMultiplier.
+
+CT_PROCEDURAL_TAX
+{
+	priceMultiplier = 1.1
+}
+
+!CT_PROCEDURAL_TAX:LAST[CryoTanks] {}
 
 @PART[procedural*Liquid]:NEEDS[ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
 {
 	@MODULE[TankContentSwitcher]
 	{
+		// Values calculated using CryoTanks' B9_TANK_TYPE definitions
+		// unitsPerT = unitsPerVolume / tankMass
+		//    Note: tankMass is "the mass that this tank type has, per unit of volume" so really it's more of a tankDensity but ¯\_(ツ)_/¯
+		// ref: https://github.com/post-kerbin-mining-corporation/CryoTanks/blob/master/GameData/CryoTanks/Patches/CryoTanksFuelTankTypes.cfg
+		
+		ratioPPDDtoB9TM = 174.24	// Magic number? I'd love to know what it logically represents
+		
+		// Stock resources configured by ProceduralParts
+		!TANK_TYPE_OPTION[Mixed] {}
+		!TANK_TYPE_OPTION[LiquidFuel] {}
+		!TANK_TYPE_OPTION[Oxidizer] {}
 		TANK_TYPE_OPTION
 		{
-			name = LqdHydrogen
-			dryDensity = 0.0187
-			costMultiplier = 1.61
+			name = #LOC_CryoTanks_switcher_fuel_lfox
+			dryDensity = #$@B9_TANK_TYPE[LFOX]/tankMass$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			costMultiplier = 0.313
 			RESOURCE
 			{
-				name = LqdHydrogen
-				// 1303.79733/0.0187
-				unitsPerT = 69721.78235
-			}
-		}
-		TANK_TYPE_OPTION
-		{
-			name = HydroOxi
-			dryDensity = 0.0487
-			costMultiplier = 1.35
-			RESOURCE
-			{
-				name = LqdHydrogen
-				unitsPerKL = 868.32902
+				name = LiquidFuel
+				unitsPerT = #$@B9_TANK_TYPE[LFOX]/RESOURCE[LiquidFuel]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LFOX]/tankMass$
 			}
 			RESOURCE
 			{
 				name = Oxidizer
-				unitsPerKL = 57.8886
+				unitsPerT = #$@B9_TANK_TYPE[LFOX]/RESOURCE[Oxidizer]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LFOX]/tankMass$
 			}
 		}
 		TANK_TYPE_OPTION
 		{
-			name = MethaOxi
-			dryDensity = 0.0909
-			costMultiplier = 1.3
+			name = #LOC_CryoTanks_switcher_fuel_lf
+			dryDensity = #$@B9_TANK_TYPE[LF]/tankMass$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			costMultiplier = 0.526
+			RESOURCE
+			{
+				name = LiquidFuel
+				unitsPerT = #$@B9_TANK_TYPE[LF]/RESOURCE[LiquidFuel]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LF]/tankMass$
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = #LOC_CryoTanks_switcher_fuel_ox
+			dryDensity = #$@B9_TANK_TYPE[OX]/tankMass$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			costMultiplier = 0.313
+			RESOURCE
+			{
+				name = Oxidizer
+				unitsPerT = #$@B9_TANK_TYPE[OX]/RESOURCE[Oxidizer]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[OX]/tankMass$
+			}
+		}
+		// CryoTanks
+		TANK_TYPE_OPTION
+		{
+			name = #LOC_CryoTanks_switcher_fuel_lh2ox
+			dryDensity = #$@B9_TANK_TYPE[LH2OCryo]/tankMass$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			costMultiplier = 0.7624
+			RESOURCE
+			{
+				name = LqdHydrogen
+				unitsPerT = #$@B9_TANK_TYPE[LH2OCryo]/RESOURCE[LqdHydrogen]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LH2OCryo]/tankMass$
+			}
+			RESOURCE
+			{
+				name = Oxidizer
+				unitsPerT = #$@B9_TANK_TYPE[LH2OCryo]/RESOURCE[Oxidizer]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LH2OCryo]/tankMass$
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = #LOC_CryoTanks_switcher_fuel_lh2
+			dryDensity = #$@B9_TANK_TYPE[LH2Cryo]/tankMass$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			costMultiplier = 0.9047
+			RESOURCE
+			{
+				name = LqdHydrogen
+				unitsPerT = #$@B9_TANK_TYPE[LH2Cryo]/RESOURCE[LqdHydrogen]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LH2Cryo]/tankMass$
+			}
+		}
+		TANK_TYPE_OPTION
+		{
+			name = #LOC_CryoTanks_switcher_fuel_methalox
+			dryDensity = #$@B9_TANK_TYPE[LMOx]/tankMass$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			costMultiplier = 0.7624
 			RESOURCE
 			{
 				name = LqdMethane
-				unitsPerKL = 325.94933
+				unitsPerT = #$@B9_TANK_TYPE[LMOx]/RESOURCE[LqdMethane]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LMOx]/tankMass$
 			}
 			RESOURCE
 			{
 				name = Oxidizer
-				unitsPerKL = 108.64977
+				unitsPerT = #$@B9_TANK_TYPE[LMOx]/RESOURCE[Oxidizer]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LMOx]/tankMass$
 			}
 		}
+		TANK_TYPE_OPTION
+		{
+			name = #LOC_CryoTanks_switcher_fuel_methane
+			dryDensity = #$@B9_TANK_TYPE[LM]/tankMass$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			costMultiplier = 0.8478
+			RESOURCE
+			{
+				name = LqdMethane
+				unitsPerT = #$@B9_TANK_TYPE[LM]/RESOURCE[LqdMethane]/unitsPerVolume$
+				@unitsPerT /= #$@B9_TANK_TYPE[LM]/tankMass$
+			}
+		}
+		// Scale up all costMultiplier values as configured at the top 
+		@TANK_TYPE_OPTION,*
+		{
+			@costMultiplier *= #$@CT_PROCEDURAL_TAX/priceMultiplier$
+		}
 	}
-
+	
 	MODULE
 	{
 		name =  ModuleCryoTank
@@ -73,70 +171,119 @@
 	}
 }
 
-@PART[proceduralTankLiquid]:NEEDS[SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
+// Prep work before SMURFF's patches run
+@PART[procedural*Liquid]:NEEDS[SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
 {
 	@MODULE[TankContentSwitcher]
 	{
-		// This runs before SMURFF.
-		// Hydrogen is already patched well by SMURFF
-		@TANK_TYPE_OPTION[HydroOxi]
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LiquidFuel]&@RESOURCE[Oxidizer]]
 		{
-			// 1/unitsPerT
-			lh2mass = 0.00001417
-			@lh2mass *= #$RESOURCE[LqdHydrogen]/unitsPerKL$
+			@name = Mixed
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LiquidFuel]&!RESOURCE[Oxidizer]]
+		{
+			@name = LiquidFuel
+		}
+		@TANK_TYPE_OPTION:HAS[!RESOURCE[LiquidFuel]&@RESOURCE[Oxidizer]]
+		{
+			@name = Oxidizer
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdHydrogen]&@RESOURCE[Oxidizer]]
+		{
+			@name = HydroOxi
+			// SMURFF has its own ideas about the LH2/Ox tank mass ratio
+			// ref: https://github.com/Kerbas-ad-astra/SMURFF/blob/505112a488b1ebf74ff655d4680f3b29f0d7fafd/GameData/SMURFF/SMURFF.cfg#L955
+			// Therefore, reconfigure the LH2/Ox TANK_TYPE_OPTION to behave consistently with SMURFF's version of the LH2OCryo B9_TANK_TYPE
+			lh2mass = #$@B9_TANK_TYPE[LH2Cryo]/tankMass$
+			@lh2mass *= #$@B9_TANK_TYPE[LH2OCryo]/RESOURCE[LqdHydrogen]/unitsPerVolume$
+			@lh2mass /= #$@B9_TANK_TYPE[LH2Cryo]/RESOURCE[LqdHydrogen]/unitsPerVolume$
 			@lh2mass /= #$@SMURFFCONFIG/lh2zbofactor$
-
-			oxmass = 0.000625
-			@oxmass *= #$RESOURCE[Oxidizer]/unitsPerKL$
+			
+			oxmass = #$@B9_TANK_TYPE[OX]/tankMass$
+			@oxmass *= #$@B9_TANK_TYPE[LH2OCryo]/RESOURCE[Oxidizer]/unitsPerVolume$
+			@oxmass /= #$@B9_TANK_TYPE[OX]/RESOURCE[Oxidizer]/unitsPerVolume$
 			@oxmass /= #$@SMURFFCONFIG/lfofactor$
-
-			@dryDensity = #$lh2mass$
-			@dryDensity += #$oxmass$
-
-			-lh2mass = delete
-			-oxmass = delete
+			
+			tankMassSMURFF = #$lh2mass$
+			@tankMassSMURFF += #$oxmass$
+			
+			@dryDensity = #$tankMassSMURFF$
+			@dryDensity *= #$../ratioPPDDtoB9TM$
+			@RESOURCE[LqdHydrogen]
+			{
+				@unitsPerT = #$@B9_TANK_TYPE[LH2OCryo]/RESOURCE[LqdHydrogen]/unitsPerVolume$
+				@unitsPerT /= #$../tankMassSMURFF$
+			}
+			@RESOURCE[Oxidizer]
+			{
+				@unitsPerT = #$@B9_TANK_TYPE[LH2OCryo]/RESOURCE[Oxidizer]/unitsPerVolume$
+				@unitsPerT /= #$../tankMassSMURFF$
+			}
 		}
-		@TANK_TYPE_OPTION[MethaOxi]
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdHydrogen]&!RESOURCE[Oxidizer]]
 		{
-			// (B9_TANK_TYPE[LM]/tankMass)
-			lh2mass = 0.000070935
-			@lh2mass *= #$RESOURCE[LqdMethane]/unitsPerKL$
-			@lh2mass /= #$@SMURFFCONFIG/lfofactor$
-
-			oxmass = 0.000625
-			@oxmass *= #$RESOURCE[Oxidizer]/unitsPerKL$
-			//TODO: maybe a factor in between LFO and LH2 should be used, isnt this too good?
-			@oxmass /= #$@SMURFFCONFIG/lfofactor$
-
-			@dryDensity = #$lh2mass$
-			@dryDensity += #$oxmass$
-
-			-lh2mass = delete
-			-oxmass = delete
+			@name = LqdHydrogen
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdMethane]&@RESOURCE[Oxidizer]]
+		{
+			@name = MethaOxi
+			@dryDensity /= #$@SMURFFCONFIG/lfofactor$
+			@RESOURCE[LqdMethane]
+			{
+				@unitsPerT *= #$@SMURFFCONFIG/lfofactor$
+			}
+			@RESOURCE[Oxidizer]
+			{
+				@unitsPerT *= #$@SMURFFCONFIG/lfofactor$
+			}
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdMethane]&!RESOURCE[Oxidizer]]
+		{
+			@name = LqdMethane
+			@dryDensity /= #$@SMURFFCONFIG/lfofactor$
+			@RESOURCE[LqdMethane]
+			{
+				@unitsPerT *= #$@SMURFFCONFIG/lfofactor$
+			}
 		}
 	}
 }
 
-// Rename HydroOxi back after SMURFF runs
-@PART[proceduralTankLiquid]:NEEDS[SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:AFTER[zzz_SMURFF]
+// Rename TANK_TYPE_OPTIONs and clean up after SMURFF runs
+@PART[procedural*Liquid]:NEEDS[SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:AFTER[zzz_SMURFF]
 {
 	@MODULE[TankContentSwitcher]
 	{
-		@TANK_TYPE_OPTION[HydroOxi]
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LiquidFuel]&@RESOURCE[Oxidizer]]
 		{
-			@name = LqdHydrogen+Oxidizer
+			@name = #LOC_CryoTanks_switcher_fuel_lfox
 		}
-	}
-}
-
-// Rename HydroOxi back in case SMURFF was not installed
-@PART[proceduralTankLiquid]:NEEDS[!SMURFF&ProceduralParts&!RealFuels&!ModularFuelTanks]:FOR[CryoTanks]
-{
-	@MODULE[TankContentSwitcher]
-	{
-		@TANK_TYPE_OPTION[HydroOxi]
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LiquidFuel]&!RESOURCE[Oxidizer]]
 		{
-			@name = LqdHydrogen+Oxidizer
+			@name = #LOC_CryoTanks_switcher_fuel_lf
+		}
+		@TANK_TYPE_OPTION:HAS[!RESOURCE[LiquidFuel]&@RESOURCE[Oxidizer]]
+		{
+			@name = #LOC_CryoTanks_switcher_fuel_ox
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdHydrogen]&@RESOURCE[Oxidizer]]
+		{
+			@name = #LOC_CryoTanks_switcher_fuel_lh2ox
+			!lh2mass = delete
+			!oxmass = delete
+			!tankMassSMURFF = delete
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdHydrogen]&!RESOURCE[Oxidizer]]
+		{
+			@name = #LOC_CryoTanks_switcher_fuel_lh2
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdMethane]&@RESOURCE[Oxidizer]]
+		{
+			@name = #LOC_CryoTanks_switcher_fuel_methalox
+		}
+		@TANK_TYPE_OPTION:HAS[@RESOURCE[LqdMethane]&!RESOURCE[Oxidizer]]
+		{
+			@name = #LOC_CryoTanks_switcher_fuel_methane
 		}
 	}
 }

--- a/GameData/CryoTanks/Patches/CryoTanksProceduralWings.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralWings.cfg
@@ -1,8 +1,59 @@
-@ProceduralWingFuelSetups:NEEDS[CryoTanks&B9_Aerospace_WingStuff|pWings&!ModularFuelTanks]
+// Procedural Wings Patch
+// Most recent author: Scialytic
+
+// Nuke the existing FuelSets for ordering purposes (PWing's selector only provides "Next" so order is important for player convenience)
+// Therefore, run ASAP to avoid causing problems for any other mods/patches that add FuelSets
+@ProceduralWingFuelSetups:FIRST:NEEDS[CryoTanks&B9_Aerospace_WingStuff|pWings&!ModularFuelTanks]
 {
+	!FuelSet,* {}
 	FuelSet
 	{
-		name = LH2
+		name = Str
+	}
+	FuelSet
+	{
+		name = #LOC_CryoTanks_switcher_fuel_lf
+		Resource
+		{
+			name = LiquidFuel
+			ratio = 1
+		}
+	}
+	FuelSet
+	{
+		name = #LOC_CryoTanks_switcher_fuel_lfox
+		Resource
+		{
+			name = LiquidFuel
+			ratio = 9
+		}
+		Resource
+		{
+			name = Oxidizer
+			ratio = 11
+		}
+	}
+	FuelSet
+	{
+		name = #LOC_CryoTanks_switcher_fuel_ox
+		Resource
+		{
+			name = Oxidizer
+			ratio = 1
+		}
+	}
+	FuelSet
+	{
+		name = Mono
+		Resource
+		{
+			name = MonoPropellant
+			ratio = 1
+		}
+	}
+	FuelSet
+	{
+		name = #LOC_CryoTanks_switcher_fuel_lh2
 		Resource
 		{
 			name = LqdHydrogen
@@ -11,11 +62,34 @@
 	}
 	FuelSet
 	{
-		name = LH2O
+		name = #LOC_CryoTanks_switcher_fuel_lh2ox
 		Resource
 		{
 			name = LqdHydrogen
-			ratio = 15
+			ratio = 3	// Yes, 3 not 15. Don't worry, it will be 15:1 units in game. LqdHydrogen has "volume = 1" in CommunityResourcePack's resource definitions, which changes how PWings calculates unitsPerVolume.
+		}				// see: https://github.com/B9-Procedural-Wings/B9-PWings-Modified/blob/baf739d7ee217622710ce668825bf4db030fcc39/B9_PWings_Fork/WingTankResource.cs#L28 for details.
+		Resource
+		{
+			name = Oxidizer
+			ratio = 1
+		}
+	}
+	FuelSet
+	{
+		name = #LOC_CryoTanks_switcher_fuel_methane
+		Resource
+		{
+			name = LqdMethane
+			ratio = 1
+		}
+	}
+	FuelSet
+	{
+		name = #LOC_CryoTanks_switcher_fuel_methalox
+		Resource
+		{
+			name = LqdMethane
+			ratio = 0.6			// 3/5 is needed here because LqdMethane is 1 L/Unit whereas stock fuels are 5 L/Unit.
 		}
 		Resource
 		{
@@ -25,18 +99,34 @@
 	}
 }
 
+// Unfortunately LqdMethane lacks "volume = 1" in CommunityResourcePack's resource definitions.  That means PWings assumes it's a 5 L/Unit resource.
+// Carrying only 20% of the fuel they should be would make the LqdMethane options practically useless.
+// AFAICS there's no other way to communicate this info to PWings.
+@RESOURCE_DEFINITION[LqdMethane]
+{
+	volume = 1
+}
+
 @PART[B9_Aero_Wing_Procedural_TypeA,Proceduralwing*]:NEEDS[CryoTanks&!ModularFuelTanks]
 {
 	MODULE
 	{
 		name =  ModuleCryoTank
-		CoolingCost = 0.09
-		CoolingEnabled = False
+		// in Ec per 1000 units per second
+		CoolingEnabled = True
 		BOILOFFCONFIG
 		{
 			FuelName = LqdHydrogen
 			// in % per hr
 			BoiloffRate = 0.05
+			CoolingCost = 0.09
+		}
+		BOILOFFCONFIG
+		{
+			FuelName = LqdMethane
+			// in % per hr
+			BoiloffRate = 0.005
+			CoolingCost = 0.045
 		}
 	}
 }

--- a/GameData/CryoTanks/Patches/CryoTanksProceduralWings.cfg
+++ b/GameData/CryoTanks/Patches/CryoTanksProceduralWings.cfg
@@ -104,7 +104,7 @@
 // AFAICS there's no other way to communicate this info to PWings.
 @RESOURCE_DEFINITION[LqdMethane]
 {
-	volume = 1
+	%volume = 1
 }
 
 @PART[B9_Aero_Wing_Procedural_TypeA,Proceduralwing*]:NEEDS[CryoTanks&!ModularFuelTanks]


### PR DESCRIPTION
If there's anything you don't like or want me to change, I'm happy to fix it.

### Procedural Fuel Tanks:
 1. Add liquid methane tank option (previously there was methalox but no option for methane alone).
 2. Improved consistency and hopefully easier maintainability of tank stats.  Now most constants are read from the appropriate B9_TANK_TYPE definition using MM variables, and then derived values are computed from there.  See code comments for details.
 3. Procedural TANK_TYPE_OPTION names now honor CryoTanks' localization, so the names are now consistent between ProceduralParts' tank type selector and the B9 switcher on normal parts.
 4. Normalized costs and added a convenient priceMultiplier to proportionally scale up the costs of procedural parts as judged appropriate.  It's also easy for players to alter this value to suit their desires.  In the attached pictures I set priceMultiplier to 1.0 just to demonstrate the cost parity with normal parts.  I set it to 1.1 (i.e. 10% procedural surcharge) in the PR, but I'll happily change it to whatever you want.
 
I have tested both the normal and SMURFF versions in a clean-ish KSP install.
 
One important note is that the current ProceduralParts sometimes displays outdated dry mass in the PAW.  I have submitted a PR for that https://github.com/KSP-RO/ProceduralParts/pull/306 but I don't know when the next release will be.

**Old (Non-SMURFF):**
![Non-SMURFF Old](https://user-images.githubusercontent.com/11653155/153733951-0ede7c4f-2e40-4e66-915f-6a1948046b93.png)

**New (Non-SMURFF):**
![Non-SMURFF New-2 5](https://user-images.githubusercontent.com/11653155/153733976-73d54949-9add-4ac6-b8e1-aebc55eec70c.png)
![Non-SMURFF New-5 0](https://user-images.githubusercontent.com/11653155/153733996-a746636e-8ccc-49d1-86d3-cec6974382eb.png)
![Non-SMURFF New-1 25](https://user-images.githubusercontent.com/11653155/153734001-94edd717-ab09-4688-8a8b-73d93be7923e.png)
![Non-SMURFF New-3 75](https://user-images.githubusercontent.com/11653155/153734004-69609141-4062-45e9-894b-2a0ffa4443d4.png)

**Old (SMURFF):**
![SMURFF Old](https://user-images.githubusercontent.com/11653155/153734058-e93efc2f-2797-40c2-b5e3-8dd782a79d31.png)

**New (SMURFF):**
![SMURFF New-2 5](https://user-images.githubusercontent.com/11653155/153734062-e25968d3-1a06-4440-9217-400dabe3a168.png)
![SMURFF New-5 0](https://user-images.githubusercontent.com/11653155/153734075-77861e46-5ee0-4688-b31d-eca8c37faac1.png)
![SMURFF New-1 25](https://user-images.githubusercontent.com/11653155/153734077-276306b4-bc39-469a-b07a-2b82b25d80cd.png)
![SMURFF New-3 75](https://user-images.githubusercontent.com/11653155/153734089-cff7ca23-2353-4ee2-b2cd-7954b12e5a78.png)


### Procedural Wings:
 1. Add liquid methane, methalox, and oxidizer-only tank options.
 2. Fix unbalanced resource amounts in LH2/Ox FuelSet.  See code comments for details.
 3. FuelSet names now honor CryoTanks' localization, so the names are now consistent between PWing's selector and the B9 switcher on normal parts.

By default (mostly meaning no FAR wing mass-strength adjustment) PWing mass ratios are:
LF,LF/Ox,Ox	~ 6
LCH4/Ox		~ 4.93
LCH4		~ 3.13
LH2/Ox		~ 2.52
LH2			~ 1.36

These seem reasonable for KSP, and in any case I don't see any way to adjust them.  PWings does its own calculations where it assumes that 1 L really is 1 L, and wing mass/shape are dictated by structural/aerodynamic demands.

**Old (note the insufficient Oxidizer):**
![pWings Old](https://user-images.githubusercontent.com/11653155/153733878-4c65110c-4642-423c-8088-b13c4e2c1a93.png)

**New:**
![pWings New](https://user-images.githubusercontent.com/11653155/153733900-433ea313-ab2d-43d8-aa86-9a5c03c88cee.png)
