### PR TITLE
Use MaximumBoiloffScale in boiloff radiation calculations.

### DIFF
--- a/Source/ModuleSimpleBoiloff.cs
+++ b/Source/ModuleSimpleBoiloff.cs
@@ -492,7 +492,7 @@ namespace SimpleBoiloff
 
       if (ShortwaveFluxAffectsBoiloff || LongwaveFluxAffectsBoiloff)
       {
-        fluxScale = Math.Max((planetFlux / LongwaveFluxBaseline + (solarFlux * Albedo) / ShortwaveFluxBaseline) / 2.0f, MinimumBoiloffScale);
+        fluxScale = Math.Min(Math.Max((planetFlux / LongwaveFluxBaseline + (solarFlux * Albedo) / ShortwaveFluxBaseline) / 2.0f, MinimumBoiloffScale), MaximumBoiloffScale);
       }
       else
       {


### PR DESCRIPTION
The previous radiative boiloff code clamped radiative effects to `MinimumBoiloffScale`, but left `MaximumBoiloffScale` unused. This seems to have been an oversight in the original implementation.

Having an upper bound is essential to playing with `LongwaveFluxAffectsBoiloff`, because the KSP body flux has unphysical orientation-dependent spikes (100-1000× solar).

This PR should be released together with post-kerbin-mining-corporation/SystemHeat#104, to maintain consistency.