### PR TITLE
Add B9PartSwitch dependency in CryoTanks.netkan

### DIFF
--- a/CKAN/CryoTanks.netkan
+++ b/CKAN/CryoTanks.netkan
@@ -15,7 +15,8 @@
         { "name": "CryoTanks-Core"   },
         { "name": "ModuleManager"         },
         { "name": "CommunityResourcePack" },
-        { "name": "DynamicBatteryStorage" }
+        { "name": "DynamicBatteryStorage" },
+        { "name": "B9PartSwitch"          }
     ],
     "supports": [
         { "name": "KerbalAtomics" },


### PR DESCRIPTION
Without this, CryoTanks will remove resources from stock tanks.

If you'd prefer, we could assume ownership of the netkan metadata on the CKAN side as well.

This will resolve https://github.com/KSP-CKAN/NetKAN/issues/9894